### PR TITLE
add library version compat matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ SBT Configuration:
 libraryDependencies += "org.sangria-graphql" %% "sangria-play-json" % "0.3.2"
 ```
 
+## Compatibility matrix
+
+|Sangri-play-json |play-json |sangria-marshalling-api|
+|-----------------|----------|-----------------------|
+|v0.1.0           | 2.4.6    | 0.1.0                 |
+|v0.2.0           | 2.4.6    | 0.1.1                 |
+|v0.2.1           | 2.5.0    | 0.1.1                 |
+|v0.3.0           | 2.5.0    | 0.2.0                 |
+|v0.3.1           | 2.5.1    | 0.2.0                 |
+|v0.3.2           | 2.5.3    | 0.2.1                 |
+
+
 ## License
 
 **sangria-play-json** is licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+


### PR DESCRIPTION
I'm still on play 2.5., and had to dig through the source to find the correct version. This makes that a bit easier. Generated like this (replacing `sangria-marshalling-api` with each dependency):

`for t in $(git tag); do echo $(echo $t; git show $t:build.sbt | grep \"sangria-marshalling-api\" | sed 's/.*% "\([^"][^"]*\)".*/\1/'); done]"')`