### PR TITLE
Upgrade to Play Json 2.6.0

### DIFF
--- a/src/main/scala/sangria/marshalling/playJson.scala
+++ b/src/main/scala/sangria/marshalling/playJson.scala
@@ -24,10 +24,11 @@ object playJson extends PlayJsonSupportLowPrioImplicits {
 
     def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]) = value match {
       case v: String ⇒ JsString(v)
-      case v: Boolean ⇒ JsBoolean(v)
+      case true ⇒ JsTrue
+      case false ⇒ JsFalse
       case v: Int ⇒ JsNumber(v)
       case v: Long ⇒ JsNumber(v)
-      case v: Float ⇒ JsNumber(v)
+      case v: Float ⇒ JsNumber(v.toDouble)
       case v: Double ⇒ JsNumber(v)
       case v: BigInt ⇒ JsNumber(BigDecimal(v))
       case v: BigDecimal ⇒ JsNumber(v)


### PR DESCRIPTION
JsBoolean is now an abstract class, which will cause a java.lang.InstantiationError on marshalling. Change to JsTrue and JsFalse (Play Json 2.6.0).

JsNumber now relies entirely on BigDecimal, which has deprecated support for Float. Explicit conversion of Float.toDouble required.