### PR TITLE
Runtime error fix on JsArray constructor call

### DIFF
--- a/src/main/scala/sangria/marshalling/playJson.scala
+++ b/src/main/scala/sangria/marshalling/playJson.scala
@@ -15,7 +15,7 @@ object playJson extends PlayJsonSupportLowPrioImplicits {
     def mapNode(builder: MapBuilder) = JsObject(builder.toSeq)
     def mapNode(keyValues: Seq[(String, JsValue)]) = JsObject(keyValues)
 
-    def arrayNode(values: Vector[JsValue]) = JsArray(values)
+    def arrayNode(values: Vector[JsValue]) = Json.arr(values)
 
     def optionalArrayNodeValue(value: Option[JsValue]) = value match {
       case Some(v) ⇒ v


### PR DESCRIPTION
Addresses the following error for some incompatible versions of play-json (ie `2.6.6`): `java.lang.NoSuchMethodError: play.api.libs.json.JsArray.<init>(Lscala/collection/IndexedSeq;)V`

I believe `def arr(JsValueWrapper*): JsArray` exists on all of 2.x?